### PR TITLE
Remove Guava and replace caching library with ExpiringMap.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     compile libs.RxAndroid
     compile libs.palette
     compile libs.rxRelay
+    compile libs.gson
     annotationProcessor libs.Dagger2Compiler
     annotationProcessor libs.butterKnifeCompiler
     provided libs.javaxAnnotation

--- a/app/src/main/java/com/vpaliy/melophile/ui/base/adapters/TracksAdapter.java
+++ b/app/src/main/java/com/vpaliy/melophile/ui/base/adapters/TracksAdapter.java
@@ -11,7 +11,7 @@ import android.widget.TextView;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
-import com.google.common.reflect.TypeToken;
+import com.google.gson.reflect.TypeToken;
 import com.vpaliy.domain.model.Track;
 import com.vpaliy.domain.playback.QueueManager;
 import com.vpaliy.melophile.R;

--- a/app/src/main/java/com/vpaliy/melophile/ui/playlist/PlaylistFragment.java
+++ b/app/src/main/java/com/vpaliy/melophile/ui/playlist/PlaylistFragment.java
@@ -23,7 +23,7 @@ import android.view.ViewGroup;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.request.target.ImageViewTarget;
-import com.google.common.reflect.TypeToken;
+import com.google.gson.reflect.TypeToken;
 import com.vpaliy.chips_lover.ChipsLayout;
 import com.vpaliy.domain.model.Track;
 import com.vpaliy.domain.model.User;

--- a/app/src/main/java/com/vpaliy/melophile/ui/playlist/PlaylistTrackAdapter.java
+++ b/app/src/main/java/com/vpaliy/melophile/ui/playlist/PlaylistTrackAdapter.java
@@ -16,7 +16,7 @@ import android.widget.TextView;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
-import com.google.common.reflect.TypeToken;
+import com.google.gson.reflect.TypeToken;
 import com.vpaliy.domain.model.Track;
 import com.vpaliy.domain.playback.QueueManager;
 import com.vpaliy.melophile.R;

--- a/app/src/main/java/com/vpaliy/melophile/ui/tracks/TracksAdapter.java
+++ b/app/src/main/java/com/vpaliy/melophile/ui/tracks/TracksAdapter.java
@@ -11,7 +11,7 @@ import android.view.ViewGroup;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
-import com.google.common.reflect.TypeToken;
+import com.google.gson.reflect.TypeToken;
 import com.vpaliy.domain.model.Track;
 import com.vpaliy.domain.playback.QueueManager;
 import com.vpaliy.melophile.R;

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     compile libs.supportAppCompat
     compile libs.soundcloud
     compile libs.RxJava
-    compile libs.guava
+    compile libs.expiringMap
     compile libs.retrofit
     compile libs.retrofitAdapter
     compile libs.retrofitConverter

--- a/data/src/main/java/com/vpaliy/data/cache/CacheStore.java
+++ b/data/src/main/java/com/vpaliy/data/cache/CacheStore.java
@@ -1,6 +1,7 @@
 package com.vpaliy.data.cache;
-import com.google.common.cache.Cache;
 import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+
 import io.reactivex.Single;
 
 /**
@@ -9,14 +10,13 @@ import io.reactivex.Single;
 
 public class CacheStore<K, V> {
 
-    private final Cache<K, V> cache;
+    private final ConcurrentMap<K, V> cache;
 
-    public CacheStore(Cache<K, V> cache) {
+    public CacheStore(ConcurrentMap<K, V> cache) {
         this.cache = cache;
     }
 
-    public void invalidate(K key) {
-        cache.invalidate(key);
+    public void invalidate(K key) {cache.remove(key);
     }
 
     public void put(K key, V value) {
@@ -28,7 +28,7 @@ public class CacheStore<K, V> {
     }
 
     public Single<V> getStream(K key) {
-        V value=cache.getIfPresent(key);
+        V value=cache.get(key);
         if(value!=null){
             return Single.just(value);
         }
@@ -36,7 +36,7 @@ public class CacheStore<K, V> {
     }
 
     public  boolean isInCache(K key) {
-        return key!=null && cache.getIfPresent(key) != null;
+        return key!=null && cache.get(key) != null;
     }
 
     public long size(){

--- a/data/src/main/java/com/vpaliy/data/repository/MusicRepository.java
+++ b/data/src/main/java/com/vpaliy/data/repository/MusicRepository.java
@@ -3,7 +3,6 @@ package com.vpaliy.data.repository;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
-import com.google.common.cache.CacheBuilder;
 import com.vpaliy.data.cache.CacheStore;
 import com.vpaliy.data.mapper.Mapper;
 import com.vpaliy.data.model.UserDetailsEntity;
@@ -20,6 +19,9 @@ import com.vpaliy.domain.repository.Repository;
 import com.vpaliy.soundcloud.model.PlaylistEntity;
 import com.vpaliy.soundcloud.model.TrackEntity;
 import com.vpaliy.soundcloud.model.UserEntity;
+
+import net.jodah.expiringmap.ExpiringMap;
+
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import io.reactivex.Completable;
@@ -68,17 +70,18 @@ public class MusicRepository implements Repository {
         this.schedulerProvider=schedulerProvider;
         this.context=context;
         //initialize cache
-        playlistCacheStore=new CacheStore<>(CacheBuilder.newBuilder()
-                .maximumSize(DEFAULT_CACHE_SIZE)
-                .expireAfterAccess(DEFAULT_CACHE_DURATION, TimeUnit.MINUTES)
+        playlistCacheStore = new CacheStore<>(ExpiringMap.builder()
+                .maxSize(DEFAULT_CACHE_SIZE)
+                .expiration(DEFAULT_CACHE_DURATION, TimeUnit.MINUTES)
                 .build());
-        trackCacheStore=new CacheStore<>(CacheBuilder.newBuilder()
-                .maximumSize(DEFAULT_CACHE_SIZE)
-                .expireAfterAccess(DEFAULT_CACHE_DURATION, TimeUnit.MINUTES)
+
+        trackCacheStore=new CacheStore<>(ExpiringMap.builder()
+                .maxSize(DEFAULT_CACHE_SIZE)
+                .expiration(DEFAULT_CACHE_DURATION, TimeUnit.MINUTES)
                 .build());
-        userCacheStore=new CacheStore<>(CacheBuilder.newBuilder()
-                .maximumSize(DEFAULT_CACHE_SIZE)
-                .expireAfterAccess(DEFAULT_CACHE_DURATION, TimeUnit.MINUTES)
+        userCacheStore=new CacheStore<>(ExpiringMap.builder()
+                .maxSize(DEFAULT_CACHE_SIZE)
+                .expiration(DEFAULT_CACHE_DURATION, TimeUnit.MINUTES)
                 .build());
     }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,6 +16,7 @@ ext {
     daggerVersion = '2.9'
     chipsLoverVersion='v1.3'
     calligraphyVersion='2.2.0'
+    expiringMapVersion='0.5.8'
     butterKnifeVersion = "8.5.1"
     supportVersion = "25.1.0"
     rxJavaVersion = '2.0.2'
@@ -37,7 +38,6 @@ ext {
     retrofitConverterVersion="2.1.0"
     retrofitAdapterVersion="2.1.0"
     picassoVersion="2.5.2"
-    guavaVersion="14.0"
     materialIconLibVersion="1.1.3"
     multiDexVersion="1.0.1"
     constraintLayoutVersion="1.0.2"
@@ -84,7 +84,6 @@ ext {
             retrofitConverter  : "com.squareup.retrofit2:converter-gson:${retrofitConverterVersion}",
             retrofitAdapter    : "com.squareup.retrofit2:adapter-rxjava:${retrofitAdapterVersion}",
             picasso            : "com.squareup.picasso:picasso:${picassoVersion}",
-            guava              : "com.google.guava:guava:${guavaVersion}",
             leakCanary         :"com.squareup.leakcanary:leakcanary-android:${leakCanaryVersion}",
             expandableTextView : "at.blogc:expandabletextview:1.0.3",
             rxRelay            : "com.jakewharton.rxrelay2:rxrelay:${rxRelayVersion}",
@@ -94,6 +93,7 @@ ext {
             multiDex           : "com.android.support:multidex:${multiDexVersion}",
             constraintLayout   : "com.android.support.constraint:constraint-layout:${constraintLayoutVersion}",
             calligraphy        : "uk.co.chrisjenx:calligraphy:${calligraphyVersion}",
+            expiringMap        : "net.jodah:expiringmap:${expiringMapVersion}",
             exoplayer          : 'com.google.android.exoplayer:exoplayer:r2.4.1',
             playPause          : 'com.github.ohoussein.playpauseview:playpauseview:1.0.1',
             bottomNavigation   : 'com.aurelhubert:ahbottomnavigation:2.0.6',


### PR DESCRIPTION
Guava is not meant to be used on Android. The caching component included in Guava that you've used is optimized for servers with multiple connections/threads/etc.

To fix that I removed Guava completely as it's usage was minimal. I fixed the imports and "rewrote" the caching part to use the ExpiringMap library https://github.com/jhalterman/expiringmap. It has 287 methods and weighs 40KB compare to I don't wanna know what Guava clocks in on those. This should reduce compile time, reduce APK size and is just plain good practice to not use a huge library for one small thing.